### PR TITLE
include location_id column in time filter output

### DIFF
--- a/travel_time_platform_plugin/algorithms/advanced.py
+++ b/travel_time_platform_plugin/algorithms/advanced.py
@@ -901,6 +901,7 @@ class TimeFilterAlgorithm(_SearchAlgorithmBase):
 
         output_fields = QgsFields(locations.fields())
         output_fields.append(QgsField("search_id", QVariant.String, "text"))
+        output_fields.append(QgsField("location_id", QVariant.String, "text"))
         output_fields.append(QgsField("reachable", QVariant.Int, "int"))
 
         for prop in self.enabled_properties():
@@ -928,6 +929,7 @@ class TimeFilterAlgorithm(_SearchAlgorithmBase):
                 for properties in location["properties"]:
                     feature = clone_feature(location["id"])
                     feature.setAttribute("search_id", result["search_id"])
+                    feature.setAttribute("location_id", location["id"])
                     feature.setAttribute("reachable", 1)
                     for prop in self.enabled_properties():
                         feature.setAttribute(
@@ -937,6 +939,7 @@ class TimeFilterAlgorithm(_SearchAlgorithmBase):
             for id_ in result["unreachable"]:
                 feature = clone_feature(id_)
                 feature.setAttribute("search_id", result["search_id"])
+                feature.setAttribute("location_id", id_)
                 feature.setAttribute("reachable", 0)
                 sink.addFeature(feature, QgsFeatureSink.FastInsert)
 


### PR DESCRIPTION
Currently, the time filter algorithm only uses location_id internally (to make the request to the API) but location_id are not part of the output. For consistency with other algorithms (and also to make it more easy to know what exact location_id was used), this PR includes it in the output.

Since it's a new attribute, this should be reasonably backwards compatible (only case where it could break existing workflows is if someone already had a `location_id` field in the input table).

@chris-traveltime Let me know if you'd like this merged or not.

